### PR TITLE
Ready for django 1.7

### DIFF
--- a/django_decorators/decorators.py
+++ b/django_decorators/decorators.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.http import HttpResponse, HttpResponseBadRequest,\
                         HttpResponseNotAllowed
-from django.utils import simplejson
+try:
+    from django.utils import simplejson
+except:
+    import simplejson
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core import serializers
 from django.db.models.query import QuerySet


### PR DESCRIPTION
simplejson is deprecated on django 1.7 and is not longer part of the package.
Fix for issue #4 
