### PR TITLE
he Readme.rst file had a non-ascii character, so load as utf-8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='http://pypi.python.org/pypi/django-decorators/',
     license='LICENSE.md',
     description='A bunch of django extra decorators.',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     install_requires=[
         "Django >= 1.1.1",
     ],


### PR DESCRIPTION
Tenia el siguiente error al tratar de instalar django-decorators en python 3.4
python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1020: ordinal not in range(128),
Realize el cambio para dar al open del archivo readme el formado unicode del archivo
